### PR TITLE
Store Telegram user identifier

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,7 +1,16 @@
 """Database package with models and repository helpers."""
 
-from .models import Base, Expense
-from .repositories import ExpenseRepository
+from .models import Base, Category, Expense, User
+from .repositories import ExpenseRepository, UserRepository
 from .session import create_session_factory, get_engine
 
-__all__ = ["Base", "Expense", "ExpenseRepository", "create_session_factory", "get_engine"]
+__all__ = [
+    "Base",
+    "User",
+    "Category",
+    "Expense",
+    "UserRepository",
+    "ExpenseRepository",
+    "create_session_factory",
+    "get_engine",
+]

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import datetime as dt
 from decimal import Decimal
 
-from sqlalchemy import DateTime, Integer, Numeric, String, UniqueConstraint
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, Numeric, String, UniqueConstraint
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 def utcnow() -> dt.datetime:
@@ -21,23 +21,34 @@ class Base(DeclarativeBase):
     created_at: Mapped[dt.datetime] = mapped_column(DateTime(), default=utcnow, nullable=False)
 
 
-class Expense(Base):
-    """Represents a single expense made by a Telegram user."""
+class User(Base):
+    """Represents a Telegram user interacting with the bot."""
 
-    __tablename__ = "expenses"
+    __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
-    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
-    category: Mapped[str] = mapped_column(String(50), nullable=False)
-    description: Mapped[str | None] = mapped_column(String(255))
-    spent_at: Mapped[dt.datetime] = mapped_column(DateTime(), default=utcnow, nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, unique=True, index=True, nullable=False
+    )
+    username: Mapped[str | None] = mapped_column(String(32))
+    first_name: Mapped[str | None] = mapped_column(String(64))
+    last_name: Mapped[str | None] = mapped_column(String(64))
+    language_code: Mapped[str | None] = mapped_column(String(8))
+    is_bot: Mapped[bool] = mapped_column(default=False, nullable=False)
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(), default=utcnow, onupdate=utcnow, nullable=False
+    )
+
+    expenses: Mapped[list["Expense"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    categories: Mapped[list["Category"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper
-        return (
-            "Expense(id={id}, user_id={user_id}, amount={amount}, category={category})".format(
-                id=self.id, user_id=self.user_id, amount=self.amount, category=self.category
-            )
+        return "User(id={id}, telegram_id={telegram_id})".format(
+            id=self.id, telegram_id=self.telegram_id
         )
 
 
@@ -50,10 +61,17 @@ class Category(Base):
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
     name: Mapped[str] = mapped_column(String(50), nullable=False)
     normalized_name: Mapped[str] = mapped_column(String(50), index=True, nullable=False)
     monthly_limit: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+
+    user: Mapped["User"] = relationship(back_populates="categories")
+    expenses: Mapped[list["Expense"]] = relationship(
+        back_populates="category", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         return (
@@ -62,6 +80,36 @@ class Category(Base):
                 user_id=self.user_id,
                 name=self.name,
                 limit=self.monthly_limit,
+            )
+        )
+
+
+class Expense(Base):
+    """Represents a single expense made by a Telegram user."""
+
+    __tablename__ = "expenses"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    category_id: Mapped[int] = mapped_column(
+        ForeignKey("categories.id", ondelete="CASCADE"), nullable=False
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(255))
+    spent_at: Mapped[dt.datetime] = mapped_column(DateTime(), default=utcnow, nullable=False)
+
+    user: Mapped["User"] = relationship(back_populates="expenses")
+    category: Mapped["Category"] = relationship(back_populates="expenses")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return (
+            "Expense(id={id}, user_id={user_id}, amount={amount}, category_id={category_id})".format(
+                id=self.id,
+                user_id=self.user_id,
+                amount=self.amount,
+                category_id=self.category_id,
             )
         )
 

--- a/app/handlers/add.py
+++ b/app/handlers/add.py
@@ -244,10 +244,12 @@ async def finalize_expense(
     """Persist the expense using data from the state and return confirmation text."""
 
     data = await state.get_data()
-    if "category_name" not in data or "amount" not in data or "spent_at" not in data:
+    required_keys = {"category_id", "category_name", "amount", "spent_at"}
+    if not required_keys.issubset(data):
         await state.clear()
         raise ValueError("Не удалось завершить добавление расхода. Попробуйте ещё раз.")
 
+    category_id = int(data["category_id"])
     category_name = str(data["category_name"])
     amount = Decimal(str(data["amount"]))
     try:
@@ -261,6 +263,7 @@ async def finalize_expense(
         user_id=user_id,
         amount=amount,
         category=category_name,
+        category_id=category_id,
         description=description,
         spent_at=spent_at,
     )

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -6,12 +6,17 @@ from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
 
+from app.services import UserService
+
 router = Router()
 
 
 @router.message(CommandStart())
-async def cmd_start(message: Message) -> None:
+async def cmd_start(message: Message, user_service: UserService) -> None:
     """Send greeting and usage instructions to the user."""
+
+    if message.from_user is not None:
+        await user_service.upsert_from_telegram(message.from_user)
 
     await message.answer(
         "Привет! \n"

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ from aiogram.client.default import DefaultBotProperties
 from app.config import ConfigurationError, get_settings
 from app.db import Base, create_session_factory, get_engine
 from app.handlers import setup_routers
-from app.services import CategoryService, ExpenseService
+from app.services import CategoryService, ExpenseService, UserService
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +35,7 @@ async def on_startup() -> tuple[Dispatcher, Bot]:
     session_factory = create_session_factory(engine)
     expense_service = ExpenseService(session_factory)
     category_service = CategoryService(session_factory)
+    user_service = UserService(session_factory)
 
     bot = Bot(
         token=settings.bot.token,
@@ -47,6 +48,7 @@ async def on_startup() -> tuple[Dispatcher, Bot]:
     dispatcher["settings"] = settings
     dispatcher["expense_service"] = expense_service
     dispatcher["category_service"] = category_service
+    dispatcher["user_service"] = user_service
     dispatcher["engine"] = engine
 
     return dispatcher, bot

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -2,5 +2,6 @@
 
 from .categories import CategoryService
 from .expenses import ExpenseService, ExpenseSummary
+from .users import UserService
 
-__all__ = ["ExpenseService", "ExpenseSummary", "CategoryService"]
+__all__ = ["ExpenseService", "ExpenseSummary", "CategoryService", "UserService"]

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -1,0 +1,40 @@
+"""User related business logic services."""
+
+from __future__ import annotations
+
+from aiogram.types import User as TelegramUser
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.repositories import UserRepository
+
+
+class UserService:
+    """Business logic for tracking Telegram user information."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def upsert_from_telegram(self, telegram_user: TelegramUser) -> None:
+        """Create or update a user record based on Telegram profile data."""
+
+        async with self._session_factory() as session:
+            repository = UserRepository(session)
+            existing = await repository.get_by_telegram_id(telegram_user.id)
+            payload = {
+                "telegram_id": telegram_user.id,
+                "username": telegram_user.username,
+                "first_name": telegram_user.first_name,
+                "last_name": telegram_user.last_name,
+                "language_code": telegram_user.language_code,
+                "is_bot": telegram_user.is_bot,
+            }
+            if existing is None:
+                await repository.create_user(
+                    user_id=telegram_user.id,
+                    **payload,
+                )
+            else:
+                await repository.update_user(existing, **payload)
+
+
+__all__ = ["UserService"]


### PR DESCRIPTION
## Summary
- add a users table and connect expenses and categories through foreign keys
- introduce a user service and repository to upsert Telegram user profiles on /start
- update expense flows to rely on category ids when persisting records
- persist the Telegram user identifier alongside profile details in the users table

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e7cd1028bc8322be2ad5f910fe6e14