### PR TITLE
Add /last command for viewing recent expenses

### DIFF
--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -2,7 +2,7 @@
 
 from aiogram import Router
 
-from . import add, categories, start, stats, today
+from . import add, categories, last, start, stats, today
 
 
 def setup_routers() -> Router:
@@ -12,6 +12,7 @@ def setup_routers() -> Router:
     router.include_router(start.router)
     router.include_router(add.router)
     router.include_router(categories.router)
+    router.include_router(last.router)
     router.include_router(stats.router)
     router.include_router(today.router)
     return router

--- a/app/handlers/last.py
+++ b/app/handlers/last.py
@@ -1,0 +1,41 @@
+"""Handler for the /last command."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from app.services import ExpenseService
+
+router = Router()
+
+
+@router.message(Command("last"))
+async def cmd_last(message: Message, expense_service: ExpenseService) -> None:
+    """Send the list of recent expenses with an optional limit."""
+
+    if message.from_user is None:
+        await message.answer("Не удалось определить пользователя.")
+        return
+
+    limit = 10
+    text = (message.text or "").strip()
+    if text and text != "/last":
+        parts = text.split(maxsplit=1)
+        if len(parts) > 1:
+            try:
+                limit = int(parts[1])
+            except ValueError:
+                await message.answer(
+                    "Нужно указать количество расходов числом. Пример: /last 25"
+                )
+                return
+            if limit <= 0:
+                await message.answer("Количество расходов должно быть положительным.")
+                return
+
+    report = await expense_service.render_recent_expenses_message(
+        user_id=message.from_user.id, limit=limit
+    )
+    await message.answer(report)


### PR DESCRIPTION
## Summary
- add a /last command handler that returns recent expenses with an optional limit
- extend the expense service to format recent expense reports with a default of 10 items
- register the new handler in the router setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8f5bfbde883229eb5cc57e80b640b