### PR TITLE
Add reminder scheduler and quick add keyboard

### DIFF
--- a/app/db/migrations.py
+++ b/app/db/migrations.py
@@ -1,0 +1,38 @@
+"""Lightweight database migrations for schema compatibility."""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+async def ensure_notifications_flag(connection: AsyncConnection) -> None:
+    """Ensure the ``users`` table has the ``notifications_enabled`` column."""
+
+    def _column_missing(sync_connection: Connection) -> bool:
+        inspector = inspect(sync_connection)
+        return not inspector.has_column("users", "notifications_enabled")
+
+    if await connection.run_sync(_column_missing):
+        await connection.execute(
+            text(
+                """
+                ALTER TABLE users
+                ADD COLUMN notifications_enabled BOOLEAN NOT NULL DEFAULT 1
+                """
+            )
+        )
+        await connection.execute(
+            text(
+                """
+                UPDATE users
+                SET notifications_enabled = 1
+                WHERE notifications_enabled IS NULL
+                """
+            )
+        )
+
+
+__all__ = ["ensure_notifications_flag"]
+

--- a/app/db/migrations.py
+++ b/app/db/migrations.py
@@ -12,7 +12,11 @@ async def ensure_notifications_flag(connection: AsyncConnection) -> None:
 
     def _column_missing(sync_connection: Connection) -> bool:
         inspector = inspect(sync_connection)
-        return not inspector.has_column("users", "notifications_enabled")
+        if not inspector.has_table("users"):
+            return False
+
+        columns = inspector.get_columns("users")
+        return all(column["name"] != "notifications_enabled" for column in columns)
 
     if await connection.run_sync(_column_missing):
         await connection.execute(

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import datetime as dt
 from decimal import Decimal
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, Numeric, String, UniqueConstraint
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -35,6 +44,9 @@ class User(Base):
     last_name: Mapped[str | None] = mapped_column(String(64))
     language_code: Mapped[str | None] = mapped_column(String(8))
     is_bot: Mapped[bool] = mapped_column(default=False, nullable=False)
+    notifications_enabled: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False
+    )
     updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(), default=utcnow, onupdate=utcnow, nullable=False
     )

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -2,7 +2,7 @@
 
 from aiogram import Router
 
-from . import add, categories, last, start, stats, today
+from . import add, categories, last, reminders, start, stats, today
 
 
 def setup_routers() -> Router:
@@ -13,6 +13,7 @@ def setup_routers() -> Router:
     router.include_router(add.router)
     router.include_router(categories.router)
     router.include_router(last.router)
+    router.include_router(reminders.router)
     router.include_router(stats.router)
     router.include_router(today.router)
     return router

--- a/app/handlers/reminders.py
+++ b/app/handlers/reminders.py
@@ -1,0 +1,103 @@
+"""Handlers related to daily spending reminders."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+from aiogram import F, Router
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, Message
+
+from app.handlers.add import start_add_expense_flow
+from app.services import (
+    ADD_EXPENSE_ACTION,
+    CategoryService,
+    ReminderAction,
+    ReminderService,
+    TOGGLE_REMINDER_ACTION,
+    UserService,
+)
+
+router = Router()
+
+REMINDER_ENABLED_TEXT = "Напоминания включены. Напишу в 22:00, если трат не будет."
+REMINDER_DISABLED_TEXT = (
+    "Напоминания выключены. Вернуть их можно командой /reminder."
+)
+
+
+@router.message(Command("reminder"))
+async def cmd_reminder(
+    message: Message,
+    reminder_service: ReminderService,
+    user_service: UserService,
+) -> None:
+    """Toggle reminder status for the current user."""
+
+    if message.from_user is None:
+        await message.answer("Не удалось определить пользователя.")
+        return
+
+    await user_service.upsert_from_telegram(message.from_user)
+    try:
+        enabled = await reminder_service.toggle_notifications(message.from_user.id)
+    except ValueError:
+        await message.answer("Не удалось изменить настройки напоминаний.")
+        return
+
+    await message.answer(REMINDER_ENABLED_TEXT if enabled else REMINDER_DISABLED_TEXT)
+
+
+@router.callback_query(ReminderAction.filter(F.action == ADD_EXPENSE_ACTION))
+async def reminder_add_expense(
+    callback: CallbackQuery,
+    category_service: CategoryService,
+    state: FSMContext,
+) -> None:
+    """Start the expense creation flow from the reminder button."""
+
+    if callback.from_user is None or callback.message is None:
+        await callback.answer()
+        return
+
+    await start_add_expense_flow(
+        callback.message,
+        user_id=callback.from_user.id,
+        category_service=category_service,
+        state=state,
+    )
+    await callback.answer()
+
+
+@router.callback_query(ReminderAction.filter(F.action == TOGGLE_REMINDER_ACTION))
+async def reminder_toggle(
+    callback: CallbackQuery,
+    reminder_service: ReminderService,
+    user_service: UserService,
+) -> None:
+    """Toggle reminder status using the inline button."""
+
+    if callback.from_user is None:
+        await callback.answer()
+        return
+
+    await user_service.upsert_from_telegram(callback.from_user)
+    try:
+        enabled = await reminder_service.toggle_notifications(callback.from_user.id)
+    except ValueError:
+        await callback.answer("Не удалось изменить настройки.", show_alert=True)
+        return
+
+    response_text = REMINDER_ENABLED_TEXT if enabled else REMINDER_DISABLED_TEXT
+
+    if callback.message is not None:
+        with suppress(TelegramBadRequest):
+            await callback.message.edit_reply_markup()
+        await callback.message.answer(response_text)
+        await callback.answer(
+            "Напоминания включены" if enabled else "Напоминания отключены"
+        )
+    else:
+        await callback.answer(response_text, show_alert=True)

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -24,5 +24,6 @@ async def cmd_start(message: Message, user_service: UserService) -> None:
         "/add <b>199 еда Обед</b> - Можно добавить сразу \n"
         "/categories — Категории и управление лимитами \n"
         "/stats - Статистика за месяц\n"
-        "/today - Сегодняшние траты"
+        "/today - Сегодняшние траты\n"
+        "/reminder - Ежедневное напоминание о тратах"
     )

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from aiogram.client.default import DefaultBotProperties
 
 from app.config import ConfigurationError, get_settings
 from app.db import Base, create_session_factory, get_engine
+from app.db.migrations import ensure_notifications_flag
 from app.handlers import setup_routers
 from app.services import (
     CategoryService,
@@ -39,6 +40,7 @@ async def on_startup() -> tuple[Dispatcher, Bot, AsyncIOScheduler]:
 
     engine = get_engine(settings)
     async with engine.begin() as connection:
+        await ensure_notifications_flag(connection)
         await connection.run_sync(Base.metadata.create_all)
 
     session_factory = create_session_factory(engine)

--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import logging
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from aiogram import Bot, Dispatcher
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
@@ -13,13 +15,20 @@ from aiogram.client.default import DefaultBotProperties
 from app.config import ConfigurationError, get_settings
 from app.db import Base, create_session_factory, get_engine
 from app.handlers import setup_routers
-from app.services import CategoryService, ExpenseService, UserService
+from app.services import (
+    CategoryService,
+    ExpenseService,
+    ReminderService,
+    UserService,
+    REMINDER_TEXT,
+    build_reminder_keyboard,
+)
 
 logger = logging.getLogger(__name__)
 
 
-async def on_startup() -> tuple[Dispatcher, Bot]:
-    """Configure application components and return dispatcher and bot."""
+async def on_startup() -> tuple[Dispatcher, Bot, AsyncIOScheduler]:
+    """Configure application components and return dispatcher, bot and scheduler."""
 
     settings = get_settings()
 
@@ -36,6 +45,7 @@ async def on_startup() -> tuple[Dispatcher, Bot]:
     expense_service = ExpenseService(session_factory)
     category_service = CategoryService(session_factory)
     user_service = UserService(session_factory)
+    reminder_service = ReminderService(session_factory)
 
     bot = Bot(
         token=settings.bot.token,
@@ -49,15 +59,26 @@ async def on_startup() -> tuple[Dispatcher, Bot]:
     dispatcher["expense_service"] = expense_service
     dispatcher["category_service"] = category_service
     dispatcher["user_service"] = user_service
+    dispatcher["reminder_service"] = reminder_service
     dispatcher["engine"] = engine
 
-    return dispatcher, bot
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(
+        send_daily_reminders,
+        "cron",
+        hour=22,
+        minute=0,
+        args=(dispatcher, bot),
+    )
+    scheduler.start()
+
+    return dispatcher, bot, scheduler
 
 
 async def main() -> None:
     """Run polling using the configured dispatcher and bot."""
 
-    dispatcher, bot = await on_startup()
+    dispatcher, bot, scheduler = await on_startup()
     engine = dispatcher["engine"]
 
     try:
@@ -67,7 +88,50 @@ async def main() -> None:
         await dispatcher.storage.close()
         await dispatcher.storage.wait_closed()
         await bot.session.close()
+        await scheduler.shutdown(wait=False)
         await engine.dispose()
+
+
+async def send_daily_reminders(dispatcher: Dispatcher, bot: Bot) -> None:
+    """Send reminder messages to users without expenses for today."""
+
+    reminder_service: ReminderService = dispatcher["reminder_service"]
+    expense_service: ExpenseService = dispatcher["expense_service"]
+
+    today = dt.date.today()
+    users = await reminder_service.list_users_with_notifications()
+    if not users:
+        return
+
+    for user in users:
+        try:
+            has_expenses = await expense_service.has_expenses_on_date(
+                user_id=user.id,
+                date_value=today,
+            )
+        except Exception as error:  # pragma: no cover - defensive logging
+            logger.warning(
+                "Failed to check expenses for user %s: %s",
+                user.telegram_id,
+                error,
+            )
+            continue
+
+        if has_expenses:
+            continue
+
+        try:
+            await bot.send_message(
+                chat_id=user.telegram_id,
+                text=REMINDER_TEXT,
+                reply_markup=build_reminder_keyboard(),
+            )
+        except Exception as error:  # pragma: no cover - defensive logging
+            logger.warning(
+                "Failed to send reminder to user %s: %s",
+                user.telegram_id,
+                error,
+            )
 
 
 if __name__ == "__main__":

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -2,6 +2,25 @@
 
 from .categories import CategoryService
 from .expenses import ExpenseService, ExpenseSummary
+from .reminders import (
+    ReminderAction,
+    ReminderService,
+    REMINDER_TEXT,
+    ADD_EXPENSE_ACTION,
+    TOGGLE_REMINDER_ACTION,
+    build_reminder_keyboard,
+)
 from .users import UserService
 
-__all__ = ["ExpenseService", "ExpenseSummary", "CategoryService", "UserService"]
+__all__ = [
+    "ExpenseService",
+    "ExpenseSummary",
+    "CategoryService",
+    "ReminderService",
+    "ReminderAction",
+    "REMINDER_TEXT",
+    "ADD_EXPENSE_ACTION",
+    "TOGGLE_REMINDER_ACTION",
+    "build_reminder_keyboard",
+    "UserService",
+]

--- a/app/services/expenses.py
+++ b/app/services/expenses.py
@@ -91,6 +91,24 @@ class ExpenseService:
             description=description,
         )
 
+    async def has_expenses_on_date(
+        self,
+        user_id: int,
+        date_value: dt.date,
+    ) -> bool:
+        """Return ``True`` if the user has expenses for the provided date."""
+
+        start = dt.datetime.combine(date_value, dt.time.min)
+        end = start + dt.timedelta(days=1)
+
+        async with self._session_factory() as session:
+            repository = ExpenseRepository(session)
+            return await repository.has_expenses_in_period(
+                user_id=user_id,
+                start=start,
+                end=end,
+            )
+
     async def get_today_summary(self, user_id: int, now: dt.datetime | None = None) -> ExpenseSummary:
         """Return summary of today's expenses for the given user."""
 

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from aiogram.filters.callback_data import CallbackData
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
@@ -16,7 +14,6 @@ from app.db.repositories import UserRepository
 REMINDER_TEXT: str = "💭 Сегодня пока нет трат. Что-нибудь купить успел?"
 
 
-@dataclass(slots=True)
 class ReminderAction(CallbackData, prefix="remind"):
     """Callback data schema for reminder-related inline buttons."""
 

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -1,0 +1,100 @@
+"""Reminder related business logic services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aiogram.filters.callback_data import CallbackData
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.models import User
+from app.db.repositories import UserRepository
+
+
+REMINDER_TEXT: str = "💭 Сегодня пока нет трат. Что-нибудь купить успел?"
+
+
+@dataclass(slots=True)
+class ReminderAction(CallbackData, prefix="remind"):
+    """Callback data schema for reminder-related inline buttons."""
+
+    action: str
+
+
+ADD_EXPENSE_ACTION = "add"
+TOGGLE_REMINDER_ACTION = "toggle"
+
+
+def build_reminder_keyboard() -> InlineKeyboardMarkup:
+    """Return inline keyboard for the daily reminder message."""
+
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text="➕ Добавить расход",
+        callback_data=ReminderAction(action=ADD_EXPENSE_ACTION).pack(),
+    )
+    builder.button(
+        text="🔕 Отключить напоминания",
+        callback_data=ReminderAction(action=TOGGLE_REMINDER_ACTION).pack(),
+    )
+    builder.adjust(2)
+    return builder.as_markup()
+
+
+class ReminderService:
+    """Business logic for working with daily spending reminders."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def toggle_notifications(self, user_id: int) -> bool:
+        """Toggle notification status for the user and return the new state."""
+
+        async with self._session_factory() as session:
+            repository = UserRepository(session)
+            user = await repository.get_by_id(user_id)
+            if user is None:
+                raise ValueError("Пользователь не найден")
+            updated = await repository.toggle_notifications(user)
+        return bool(updated.notifications_enabled)
+
+    async def disable_notifications(self, user_id: int) -> bool:
+        """Disable notifications for the user and return the resulting state."""
+
+        async with self._session_factory() as session:
+            repository = UserRepository(session)
+            user = await repository.get_by_id(user_id)
+            if user is None:
+                raise ValueError("Пользователь не найден")
+            updated = await repository.set_notifications(user, enabled=False)
+        return bool(updated.notifications_enabled)
+
+    async def notifications_enabled(self, user_id: int) -> bool:
+        """Return ``True`` if the user has reminders enabled."""
+
+        async with self._session_factory() as session:
+            repository = UserRepository(session)
+            user = await repository.get_by_id(user_id)
+            if user is None:
+                raise ValueError("Пользователь не найден")
+        return bool(user.notifications_enabled)
+
+    async def list_users_with_notifications(self) -> list[User]:
+        """Return all users who opted-in for daily reminders."""
+
+        async with self._session_factory() as session:
+            repository = UserRepository(session)
+            users = await repository.list_with_notifications_enabled()
+        return users
+
+
+__all__ = [
+    "ReminderService",
+    "ReminderAction",
+    "ADD_EXPENSE_ACTION",
+    "TOGGLE_REMINDER_ACTION",
+    "build_reminder_keyboard",
+    "REMINDER_TEXT",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ SQLAlchemy>=2.0.25
 aiosqlite>=0.19.0
 python-dotenv>=1.0.0
 greenlet==3.2.4
+apscheduler>=3.10.4


### PR DESCRIPTION
## Summary
- add daily reminder scheduler with toggleable user preference
- introduce reminder handlers and service with inline actions for adding expenses or disabling alerts
- show a quick "add another" reply keyboard after expenses are stored

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e8fdb2009c832286e5eb6386036913