### PR TITLE
Add smart free-form expense entry flow

### DIFF
--- a/app/handlers/add.py
+++ b/app/handlers/add.py
@@ -67,6 +67,24 @@ async def explain_add_usage(message: Message, state: FSMContext) -> None:
     await message.answer("Напиши расход, например: 'еда 2500'.")
 
 
+async def start_add_expense_flow(
+    message: Message,
+    *,
+    user_id: int,
+    category_service: CategoryService,
+    state: FSMContext,
+) -> None:
+    """Initiate the free-form expense flow triggered from other handlers."""
+
+    categories = await category_service.list_categories(user_id=user_id)
+    if not categories:
+        await message.answer(NO_CATEGORIES_TEXT)
+        return
+
+    await _reset_to_idle(state)
+    await message.answer("Напиши расход, например: 'еда 2500'.")
+
+
 @router.message(StateFilter(ExpenseInputStates.IDLE, None), F.text)
 async def handle_free_form_message(
     message: Message,

--- a/app/handlers/common.py
+++ b/app/handlers/common.py
@@ -1,0 +1,51 @@
+"""Common inline keyboards for handlers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from app.db.models import Category
+
+
+def build_comment_choice_keyboard(*, enter_data: str, skip_data: str) -> InlineKeyboardMarkup:
+    """Return inline keyboard with options to enter or skip a comment."""
+
+    builder = InlineKeyboardBuilder()
+    builder.button(text="✏️ Ввести", callback_data=enter_data)
+    builder.button(text="⏭ Пропустить", callback_data=skip_data)
+    builder.adjust(2)
+    return builder.as_markup()
+
+
+def build_category_shortcuts_keyboard(
+    categories: Sequence[Category],
+    *,
+    encode: Callable[[Category], str],
+    all_categories_data: str,
+) -> InlineKeyboardMarkup:
+    """Return inline keyboard with a few quick category options."""
+
+    builder = InlineKeyboardBuilder()
+    for category in categories:
+        builder.button(text=category.name, callback_data=encode(category))
+    builder.button(text="Все категории", callback_data=all_categories_data)
+    builder.adjust(2)
+    return builder.as_markup()
+
+
+def build_all_categories_keyboard(
+    categories: Sequence[Category],
+    *,
+    encode: Callable[[Category], str],
+) -> InlineKeyboardMarkup:
+    """Return inline keyboard with the full list of categories."""
+
+    builder = InlineKeyboardBuilder()
+    for category in categories:
+        builder.button(text=category.name, callback_data=encode(category))
+    if categories:
+        builder.adjust(2)
+    return builder.as_markup()

--- a/app/services/categories.py
+++ b/app/services/categories.py
@@ -52,6 +52,17 @@ class CategoryService:
             repository = CategoryRepository(session)
             return await repository.get_by_id(user_id=user_id, category_id=category_id)
 
+    async def find_category_by_name(self, user_id: int, name: str) -> Category | None:
+        """Return a category by name using normalized comparison."""
+
+        normalized = self._normalize_name(name)
+
+        async with self._session_factory() as session:
+            repository = CategoryRepository(session)
+            return await repository.get_by_normalized_name(
+                user_id=user_id, normalized_name=normalized
+            )
+
     async def create_category(self, user_id: int, name: str, monthly_limit: Decimal) -> str:
         """Create a category using validated data and return confirmation text."""
 

--- a/app/services/expenses_parser.py
+++ b/app/services/expenses_parser.py
@@ -1,0 +1,58 @@
+"""Utilities for parsing expense input messages."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+AMOUNT_PATTERN = re.compile(r"(?<!\S)(?P<amount>[\d\s.,]+)(?!\S)")
+
+
+def parse_expense_text(text: str) -> dict[str, Optional[int | str]]:
+    """Parse free form expense text into structured components.
+
+    Parameters
+    ----------
+    text:
+        Raw message received from the user.
+
+    Returns
+    -------
+    dict
+        Mapping with ``amount`` (int), ``category`` (str) and ``description`` (str)
+        keys. Values are set to ``None`` when not recognized. A description is
+        detected only when an amount is present and corresponds to the text after
+        the numeric value. Category corresponds to the text before the amount or
+        the whole message if no amount was found.
+    """
+
+    cleaned = (text or "").strip()
+    if not cleaned:
+        return {"amount": None, "category": None, "description": None}
+
+    match = AMOUNT_PATTERN.search(cleaned)
+    if match is None:
+        if any(char.isdigit() for char in cleaned):
+            return {"amount": None, "category": None, "description": None}
+        return {"amount": None, "category": cleaned, "description": None}
+
+    raw_amount = match.group("amount")
+    normalized_amount = re.sub(r"[^\d]", "", raw_amount)
+    if not normalized_amount:
+        return {"amount": None, "category": None, "description": None}
+
+    amount = int(normalized_amount)
+    if amount <= 0:
+        return {"amount": None, "category": None, "description": None}
+
+    before = cleaned[: match.start()].strip()
+    after = cleaned[match.end() :].strip()
+
+    category = before or None
+    description = after or None
+
+    return {
+        "amount": amount,
+        "category": category,
+        "description": description,
+    }


### PR DESCRIPTION
## Summary
- implement a new FSM-based expense input handler that parses free-form messages and guides users through amount, category, and comment steps with inline buttons
- add reusable inline keyboard builders and a text parser to extract amount, category, and description fragments from user messages
- expose helpers to resolve categories by name and surface recently used categories for quick selection

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e9179184f88322b2ffcf74eb7b51af